### PR TITLE
Fix misspelling in cling-build section in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -62,7 +62,7 @@ git checkout cling-patches
 cd ../..
 mkdir build inst
 cd build
-cmake -DCMAKE_INSTALL_PREFIX=../inst ../src
+cmake -DCMAKE_INSTALL_PREFIX=../inst ..
 cmake --build .
 cmake --build . --target install
 ```


### PR DESCRIPTION
I think, I found misspelling in cling-build section in readme.
![default](https://user-images.githubusercontent.com/32711843/36394704-8423b988-15c6-11e8-8917-5a05fb9183f9.png)

After changing '../src' to '..' cmake starts building.