### PR TITLE
Required standard was set at C++11, but the readme states that C++17 …

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,7 +1,7 @@
 cmake_minimum_required(VERSION 3.5)
 
 set(LLVM_NO_DEAD_STRIP 1)
-set(CMAKE_CXX_STANDARD 11)
+set(CMAKE_CXX_STANDARD 17)
 set(CMAKE_CXX_STANDARD_REQUIRED ON)
 
 project(inspector)

--- a/include/inspector/common.h
+++ b/include/inspector/common.h
@@ -1,0 +1,10 @@
+#pragma once
+
+// Common utilities etc. that need to be included early.
+
+#ifdef USE_EXCEPTION_SPECIFICATIONS
+    #define THROW(...) throw( __VA_ARGS__ )
+#else
+    #define THROW(...)
+#endif
+

--- a/include/inspector/prompt.h
+++ b/include/inspector/prompt.h
@@ -1,3 +1,4 @@
+#include "inspector/common.h"
 #include "inspector/socket.h"
 
 #include <cling/Utils/Output.h>

--- a/include/inspector/repl.h
+++ b/include/inspector/repl.h
@@ -1,5 +1,7 @@
 #pragma once
 
+#include "inspector/common.h"
+
 #include "string"
 
 extern "C" {

--- a/include/inspector/socket.h
+++ b/include/inspector/socket.h
@@ -1,5 +1,7 @@
 #pragma once
 
+#include "inspector/common.h"
+
 #include <string>            // For string
 #include <exception>         // For exception class
 
@@ -16,18 +18,18 @@ public:
    *   @param incSysMsg true if system message (from strerror(errno))
    *   should be postfixed to the user provided message
    */
-  SocketException(const string &message, bool inclSysMsg = false) throw();
+  SocketException(const string &message, bool inclSysMsg = false) noexcept;
 
   /**
    *   Provided just to guarantee that no exceptions are thrown.
    */
-  ~SocketException() throw();
+  ~SocketException() noexcept;
 
   /**
    *   Get the exception message
    *   @return exception message
    */
-  const char *what() const throw();
+  const char *what() const noexcept;
 
 private:
   string userMessage;  // Exception message
@@ -48,14 +50,14 @@ public:
    *   @return local address of socket
    *   @exception SocketException thrown if fetch fails
    */
-  string getLocalAddress() throw(SocketException);
+  string getLocalAddress() THROW(SocketException);
 
   /**
    *   Get the local port
    *   @return local port of socket
    *   @exception SocketException thrown if fetch fails
    */
-  unsigned short getLocalPort() throw(SocketException);
+  unsigned short getLocalPort() THROW(SocketException);
 
   /**
    *   Set the local port to the specified port and the local address
@@ -63,7 +65,7 @@ public:
    *   @param localPort local port
    *   @exception SocketException thrown if setting local port fails
    */
-  void setLocalPort(unsigned short localPort) throw(SocketException);
+  void setLocalPort(unsigned short localPort) THROW(SocketException);
 
   /**
    *   Set the local port to the specified port and the local address
@@ -74,7 +76,7 @@ public:
    *   @exception SocketException thrown if setting local port or address fails
    */
   void setLocalAddressAndPort(const string &localAddress, 
-    unsigned short localPort = 0) throw(SocketException);
+    unsigned short localPort = 0) THROW(SocketException);
 
   /**
    *   If WinSock, unload the WinSock DLLs; otherwise do nothing.  We ignore
@@ -89,7 +91,7 @@ public:
    *   @return number of bytes read, 0 for EOF, and -1 for error
    *   @exception SocketException thrown WinSock clean up fails
    */
-  static void cleanUp() throw(SocketException);
+  static void cleanUp() THROW(SocketException);
 
   /**
    *   Resolve the specified service for the specified protocol to the
@@ -107,7 +109,7 @@ private:
 
 protected:
   int sockDesc;              // Socket descriptor
-  Socket(int type, int protocol) throw(SocketException);
+  Socket(int type, int protocol) THROW(SocketException);
   Socket(int sockDesc);
 };
 
@@ -124,7 +126,7 @@ public:
    *   @exception SocketException thrown if unable to establish connection
    */
   void connect(const string &foreignAddress, unsigned short foreignPort)
-    throw(SocketException);
+    THROW(SocketException);
 
   /**
    *   Write the given buffer to this socket.  Call connect() before
@@ -133,7 +135,7 @@ public:
    *   @param bufferLen number of bytes from buffer to be written
    *   @exception SocketException thrown if unable to send data
    */
-  void send(const void *buffer, int bufferLen) throw(SocketException);
+  void send(const void *buffer, int bufferLen) THROW(SocketException);
 
   /**
    *   Read into the given buffer up to bufferLen bytes data from this
@@ -143,24 +145,24 @@ public:
    *   @return number of bytes read, 0 for EOF, and -1 for error
    *   @exception SocketException thrown if unable to receive data
    */
-  int recv(void *buffer, int bufferLen) throw(SocketException);
+  int recv(void *buffer, int bufferLen) THROW(SocketException);
 
   /**
    *   Get the foreign address.  Call connect() before calling recv()
    *   @return foreign address
    *   @exception SocketException thrown if unable to fetch foreign address
    */
-  string getForeignAddress() throw(SocketException);
+  string getForeignAddress() THROW(SocketException);
 
   /**
    *   Get the foreign port.  Call connect() before calling recv()
    *   @return foreign port
    *   @exception SocketException thrown if unable to fetch foreign port
    */
-  unsigned short getForeignPort() throw(SocketException);
+  unsigned short getForeignPort() THROW(SocketException);
 
 protected:
-  CommunicatingSocket(int type, int protocol) throw(SocketException);
+  CommunicatingSocket(int type, int protocol) THROW(SocketException);
   CommunicatingSocket(int newConnSD);
 };
 
@@ -173,7 +175,7 @@ public:
    *   Construct a TCP socket with no connection
    *   @exception SocketException thrown if unable to create TCP socket
    */
-  TCPSocket() throw(SocketException);
+  TCPSocket() THROW(SocketException);
 
   /**
    *   Construct a TCP socket with a connection to the given foreign address
@@ -183,7 +185,7 @@ public:
    *   @exception SocketException thrown if unable to create TCP socket
    */
   TCPSocket(const string &foreignAddress, unsigned short foreignPort) 
-      throw(SocketException);
+      THROW(SocketException);
 
 private:
   // Access for TCPServerSocket::accept() connection creation
@@ -206,7 +208,7 @@ public:
    *   @exception SocketException thrown if unable to create TCP server socket
    */
   TCPServerSocket(unsigned short localPort, int queueLen = 5)
-      throw(SocketException);
+      THROW(SocketException);
 
   /**
    *   Construct a TCP socket for use with a server, accepting connections
@@ -218,15 +220,15 @@ public:
    *   @exception SocketException thrown if unable to create TCP server socket
    */
   TCPServerSocket(const string &localAddress, unsigned short localPort,
-      int queueLen = 5) throw(SocketException);
+      int queueLen = 5) THROW(SocketException);
 
   /**
    *   Blocks until a new connection is established on this socket or error
    *   @return new connection socket
    *   @exception SocketException thrown if attempt to accept a new connection fails
    */
-  TCPSocket *accept() throw(SocketException);
+  TCPSocket *accept() THROW(SocketException);
 
 private:
-  void setListen(int queueLen) throw(SocketException);
+  void setListen(int queueLen) THROW(SocketException);
 };

--- a/lib/CMakeLists.txt
+++ b/lib/CMakeLists.txt
@@ -1,3 +1,8 @@
+
+# Exception specifications are removed in C++17
+# To override back on:
+  # add_compile_definitions(USE_EXCEPTION_SPECIFICATIONS)
+
 add_library(inspector SHARED socket.cpp repl.cpp prompt.cpp)
 target_link_libraries(inspector libcling ${JSONCPP_LIBRARIES})
 target_include_directories(inspector PUBLIC ${JSONCPP_INCLUDE_DIRS})


### PR DESCRIPTION
…is targetted; replace exception specificatiosn with a macro, as these are removed in C++17; change empty specifications to `noexcept`.